### PR TITLE
🔊 添加Swagger依赖和SwaggerConfiguration配置

### DIFF
--- a/itheima-leadnews-api/itheima-leadnews-admin-api/src/main/java/com/itheima/admin/pojo/AdChannel.java
+++ b/itheima-leadnews-api/itheima-leadnews-admin-api/src/main/java/com/itheima/admin/pojo/AdChannel.java
@@ -4,6 +4,8 @@ import com.baomidou.mybatisplus.annotation.IdType;
 import com.baomidou.mybatisplus.annotation.TableField;
 import com.baomidou.mybatisplus.annotation.TableId;
 import com.baomidou.mybatisplus.annotation.TableName;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Data;
 
 import java.io.Serializable;
@@ -14,21 +16,25 @@ import java.util.Date;
  */
 @Data
 @TableName("ad_channel")
+@ApiModel(value="adChannel",description = "这个是频道对象")
 public class AdChannel implements Serializable {
 
     @TableId(value = "id", type = IdType.AUTO)
+    @ApiModelProperty(notes = "这个是主键")
     private Integer id;
 
     /**
      * 频道名称
      */
     @TableField("name")
+    @ApiModelProperty(notes = "这个是频道名称")
     private String name;
 
     /**
      * 频道描述
      */
     @TableField("description")
+    @ApiModelProperty(notes = "这个是频道描述信息")
     private String description;
 
     /**

--- a/itheima-leadnews-service/itheima-leadnews-service-admin/src/main/java/com/itheima/admin/config/SwaggerConfiguration.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-admin/src/main/java/com/itheima/admin/config/SwaggerConfiguration.java
@@ -1,0 +1,75 @@
+package com.itheima.admin.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.HashSet;
+
+
+/**
+ * @author Arthurocky
+ */
+@Configuration
+@EnableSwagger2
+public class SwaggerConfiguration {
+
+   @Bean
+   public Docket buildDocket() {
+      HashSet<String> strings = new HashSet<>();
+      strings.add("application/json");
+
+      return new Docket(DocumentationType.SWAGGER_2)
+              .apiInfo(buildApiInfo())
+              //设置返回值数据类型为json
+              .produces(strings)
+              .select()
+              // 要扫描的API(Controller)基础包
+              .apis(RequestHandlerSelectors.basePackage("com.itheima"))
+              .paths(PathSelectors.any())
+              .build();
+   }
+
+   private ApiInfo buildApiInfo() {
+      Contact contact = new Contact("黑马程序员","","");
+      return new ApiInfoBuilder()
+              .title("黑马头条-平台管理API文档")
+              .description("平台管理服务api")
+              .contact(contact)
+              .version("1.0.0").build();
+   }
+}
+/*
+（3）Swagger常用注解
+
+@Api：修饰整个类，描述Controller的作用
+
+@ApiOperation：修饰类的一个方法 标识 操作信息 接口的定义
+
+@ApiParam：单个参数的描述信息
+
+@ApiModel：描述使用到的对象信息
+
+@ApiModelProperty：描述使用到的对象的属性信息
+
+@ApiResponse：HTTP响应其中1个描述
+
+@ApiResponses：HTTP响应整体描述
+
+@ApiIgnore：使用该注解忽略这个API
+
+@ApiError ：发生错误返回的信息
+
+@ApiImplicitParam：一个请求参数
+
+@ApiImplicitParams：多个请求参数的描述信息
+
+ @ApiImplicitParam属性：
+ */

--- a/itheima-leadnews-service/itheima-leadnews-service-admin/src/main/java/com/itheima/admin/controller/AdChannelController.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-admin/src/main/java/com/itheima/admin/controller/AdChannelController.java
@@ -5,6 +5,8 @@ import com.itheima.admin.service.AdChannelService;
 import com.itheima.common.pojo.PageInfo;
 import com.itheima.common.pojo.PageRequestDto;
 import com.itheima.common.pojo.Result;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -15,20 +17,25 @@ import java.util.List;
  */
 @RestController
 @RequestMapping("/channel")
+@Api(value = "频道管理", tags = "channel管理", description = "这个是描述频道管理的接口")
 public class AdChannelController {
 
     @Autowired
     private AdChannelService adChannelService;
 
-    //查询所有
+    /**
+     * 查询所有
+     */
     @GetMapping("/findAll")
+    @ApiOperation(value="查询所有",notes = "这个是频道管理里面查询所有的频道测试用的",tags ="频道管理" )
     public Result<List<AdChannel>> findAll() {
         List<AdChannel> list = adChannelService.list();
         return Result.ok(list);
     }
 
-    //顺便 就能通过代码生成接口文档
-
+    /**
+     * 顺便 就能通过代码生成接口文档
+     */
     @PostMapping("/search")
     public Result<PageInfo<AdChannel>> search(@RequestBody PageRequestDto<AdChannel> pageRequestDto){
         PageInfo<AdChannel> pageInfo =  adChannelService.search(pageRequestDto);

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger2</artifactId>
+            <version>2.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-swagger-ui</artifactId>
+            <version>2.9.2</version>
+        </dependency>
     </dependencies>
     <dependencyManagement>
         <dependencies>


### PR DESCRIPTION
SpringBoot集成Swagger
- 引入依赖,在itheima-leadnews模块中引入该依赖(springfox-swagger2)&(springfox-swagger-ui)
- 在itheima-leadnews-service-admin工程的config包中添加一个配置类(SwaggerConfiguration)
- 在controller&AdChannel 中添加Swagger注解
- 登录  http://localhost:9001/swagger-ui.html