### PR TITLE
🚀 app端用户认证实现

### DIFF
--- a/itheima-leadnews-api/itheima-leadnews-article-api/src/main/java/com/itheima/article/feign/ApAuthorFeign.java
+++ b/itheima-leadnews-api/itheima-leadnews-article-api/src/main/java/com/itheima/article/feign/ApAuthorFeign.java
@@ -1,0 +1,31 @@
+package com.itheima.article.feign;
+
+import com.itheima.article.pojo.ApAuthor;
+import com.itheima.common.pojo.Result;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+/**
+ * @author Arthurocky
+ */
+@FeignClient(name="leadnews-article",path = "/apAuthor")
+public interface ApAuthorFeign {
+    /**
+     * 保存作者账号
+     * @param apAuthor
+     * @return
+     */
+    @PostMapping
+    public Result save(@RequestBody ApAuthor apAuthor);
+
+    /**
+     * 根据APP用户的ID 获取 作者信息
+     * @param apUserId
+     * @return
+     */
+    @GetMapping("/one/{apUserId}")
+    public ApAuthor getByApUserId(@PathVariable(name="apUserId")Integer apUserId);
+}

--- a/itheima-leadnews-api/itheima-leadnews-wemedia-api/src/main/java/com/itheima/media/feign/WmUserFeign.java
+++ b/itheima-leadnews-api/itheima-leadnews-wemedia-api/src/main/java/com/itheima/media/feign/WmUserFeign.java
@@ -1,0 +1,28 @@
+package com.itheima.media.feign;
+
+import com.itheima.common.pojo.Result;
+import com.itheima.media.pojo.WmUser;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient(name="leadnews-wemedia",path = "/wmUser")
+public interface WmUserFeign {
+    /**
+     * 创建自媒体账户信息
+     * @param wmUser
+     * @return
+     */
+    @PostMapping
+    public Result save(@RequestBody WmUser wmUser);
+
+    /**
+     * 根据apUserId获取
+     * @param apUserId
+     * @return
+     */
+    @GetMapping("/one/{apUserId}")
+    public WmUser getByApUserId(@PathVariable(name="apUserId") Integer apUserId);
+}

--- a/itheima-leadnews-common/src/main/java/com/itheima/common/constants/BusinessConstants.java
+++ b/itheima-leadnews-common/src/main/java/com/itheima/common/constants/BusinessConstants.java
@@ -29,4 +29,43 @@ public interface BusinessConstants {
         public static final Integer SHENHE_SUCCESS=9;
     }
 
+    /**
+     * 注册为自媒体账号
+     */
+    public static class WmUserConstants{
+
+        /**
+         * 有效
+         */
+        public static final Integer WM_USER_OK= 9;
+
+        /**
+         * 冻结
+         */
+        public static final Integer WM_USER_LOCKED= 0;
+
+        /**
+         * 永久失效
+         */
+        public static final Integer WM_USER_INVALID= 1;
+    }
+
+
+    public static class ApAuthorConstants{
+        /**
+         * 平台自媒体人
+         */
+        public static final Integer A_MEDIA_USER= 2;
+
+        /**
+         * 合作商
+         */
+        public static final Integer A_MEDIA_SELLER= 1;
+
+        /**
+         * 普通作者
+         */
+        public static final Integer A_MEDIA_ZERO= 0;
+    }
+
 }

--- a/itheima-leadnews-common/src/main/java/com/itheima/common/constants/BusinessConstants.java
+++ b/itheima-leadnews-common/src/main/java/com/itheima/common/constants/BusinessConstants.java
@@ -1,0 +1,32 @@
+package com.itheima.common.constants;
+
+/**
+ * @author Arthurocky
+ */
+public interface BusinessConstants {
+    /**
+     * 实名认证相关
+     */
+   public static class ApUserRealnameConstants{
+        /**
+         * 创建中
+         */
+        public static final Integer SHENHE_ING=0;
+
+        /**
+         * 待审核
+         */
+        public static final Integer SHENHE_WAITING=1;
+
+        /**
+         * 审核失败
+         */
+        public static final Integer SHENHE_FALSE=2;
+
+        /**
+         * 审核通过
+         */
+        public static final Integer SHENHE_SUCCESS=9;
+    }
+
+}

--- a/itheima-leadnews-gateway/itheima-leadnews-gateway-admin/src/main/resources/application.yml
+++ b/itheima-leadnews-gateway/itheima-leadnews-gateway-admin/src/main/resources/application.yml
@@ -35,6 +35,13 @@ spring:
             - Path=/admin/**
           filters:
             - StripPrefix= 1
+        # 用户认证
+        - id: user
+          uri: lb://leadnews-user
+          predicates:
+            - Path=/user/**
+          filters:
+            - StripPrefix= 1
 ---
 server:
   port: 6001

--- a/itheima-leadnews-service/itheima-leadnews-service-article/src/main/java/com/itheima/article/controller/ApAuthorController.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-article/src/main/java/com/itheima/article/controller/ApAuthorController.java
@@ -1,8 +1,11 @@
 package com.itheima.article.controller;
 
 
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.itheima.article.pojo.ApAuthor;
 import com.itheima.article.service.ApAuthorService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.beans.factory.annotation.Autowired;
 import io.swagger.annotations.Api;
@@ -27,6 +30,19 @@ public class ApAuthorController extends AbstractCoreController<ApAuthor> {
     public ApAuthorController(ApAuthorService apAuthorService) {
         super(apAuthorService);
         this.apAuthorService=apAuthorService;
+    }
+
+    /**
+     * 根据app用户的ID 获取作者信息
+     * @param apUserId
+     * @return
+     */
+    @GetMapping("/one/{apUserId}")
+    public ApAuthor getByApUserId(@PathVariable(name="apUserId")Integer apUserId){
+        QueryWrapper<ApAuthor> queryWrapper = new QueryWrapper<ApAuthor>();
+        queryWrapper.eq("user_id",apUserId);
+        ApAuthor apAuthor = apAuthorService.getOne(queryWrapper);
+        return apAuthor;
     }
 
 }

--- a/itheima-leadnews-service/itheima-leadnews-service-user/pom.xml
+++ b/itheima-leadnews-service/itheima-leadnews-service-user/pom.xml
@@ -29,7 +29,18 @@
             <artifactId>itheima-leadnews-core-controller</artifactId>
             <version>1.0-SNAPSHOT</version>
         </dependency>
-   
+
+        <dependency>
+            <groupId>com.itheima</groupId>
+            <artifactId>itheima-leadnews-wemedia-api</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.itheima</groupId>
+            <artifactId>itheima-leadnews-article-api</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
     </dependencies>
 
 

--- a/itheima-leadnews-service/itheima-leadnews-service-user/src/main/java/com/itheima/UserApplication.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-user/src/main/java/com/itheima/UserApplication.java
@@ -5,6 +5,7 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -17,6 +18,7 @@ import org.springframework.context.annotation.Bean;
 @SpringBootApplication
 @MapperScan(basePackages = "com.itheima.user.mapper")//扫描mapper接口所在的包即可
 @EnableDiscoveryClient//启用注册与发现
+@EnableFeignClients(basePackages = "com.itheima.*.feign")
 public class UserApplication {
     public static void main(String[] args) {
         SpringApplication.run(UserApplication.class,args);

--- a/itheima-leadnews-service/itheima-leadnews-service-user/src/main/java/com/itheima/user/controller/ApUserRealnameController.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-user/src/main/java/com/itheima/user/controller/ApUserRealnameController.java
@@ -1,12 +1,12 @@
 package com.itheima.user.controller;
 
 
+import com.itheima.common.pojo.Result;
 import com.itheima.user.pojo.ApUserRealname;
 import com.itheima.user.service.ApUserRealnameService;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import io.swagger.annotations.Api;
-import org.springframework.web.bind.annotation.RestController;
 import com.itheima.core.controller.AbstractCoreController;
 
 /**
@@ -27,6 +27,24 @@ public class ApUserRealnameController extends AbstractCoreController<ApUserRealn
     public ApUserRealnameController(ApUserRealnameService apUserRealnameService) {
         super(apUserRealnameService);
         this.apUserRealnameService=apUserRealnameService;
+    }
+
+    /**
+     * 审核通过
+     */
+    @PutMapping("/pass/{id}")
+    public Result pass(@PathVariable(name="id") Integer id){
+        apUserRealnameService.pass(id);
+        return Result.ok();
+    }
+
+    /**
+     * 驳回
+     */
+    @PutMapping("/reject/{id}")
+    public Result reject(@PathVariable(name="id")Integer id,@RequestParam(required = true,name="reason") String reason){
+        apUserRealnameService.reject(id,reason);
+        return Result.ok();
     }
 
 }

--- a/itheima-leadnews-service/itheima-leadnews-service-user/src/main/java/com/itheima/user/service/ApUserRealnameService.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-user/src/main/java/com/itheima/user/service/ApUserRealnameService.java
@@ -13,4 +13,17 @@ import com.baomidou.mybatisplus.extension.service.IService;
  */
 public interface ApUserRealnameService extends IService<ApUserRealname> {
 
+    /**
+     * 审核通过
+     * @param id
+     */
+    void pass(Integer id);
+
+    /**
+     * 审核拒绝
+     * @param id
+     * @param reason
+     */
+    void reject(Integer id, String reason);
+
 }

--- a/itheima-leadnews-service/itheima-leadnews-service-user/src/main/java/com/itheima/user/service/impl/ApUserRealnameServiceImpl.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-user/src/main/java/com/itheima/user/service/impl/ApUserRealnameServiceImpl.java
@@ -1,10 +1,17 @@
 package com.itheima.user.service.impl;
 
+import com.itheima.common.constants.BusinessConstants;
+import com.itheima.common.constants.SystemConstants;
+import com.itheima.user.mapper.ApUserMapper;
+import com.itheima.user.pojo.ApUser;
 import com.itheima.user.pojo.ApUserRealname;
 import com.itheima.user.mapper.ApUserRealnameMapper;
 import com.itheima.user.service.ApUserRealnameService;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 /**
  * <p>
@@ -17,4 +24,34 @@ import org.springframework.stereotype.Service;
 @Service
 public class ApUserRealnameServiceImpl extends ServiceImpl<ApUserRealnameMapper, ApUserRealname> implements ApUserRealnameService {
 
+    @Autowired
+    private ApUserRealnameMapper apUserRealnameMapper;
+
+    @Override
+    public void pass(Integer id)
+    {
+        ApUserRealname apUser = new ApUserRealname();
+        apUser.setUserId(id);
+        apUser.setStatus(BusinessConstants.ApUserRealnameConstants.SHENHE_SUCCESS);
+        apUserRealnameMapper.updateById(apUser);
+
+        //通过远程调用实现创建作者的账号  todo
+
+        //通过远程调用实现创建作者的账号  todo
+
+
+    }
+
+
+    @Override
+    public void reject(Integer id, String reason) {
+        ApUserRealname apUserRealname = new ApUserRealname();
+        apUserRealname.setId(id);
+        apUserRealname.setReason(reason);
+        //更新时间
+        apUserRealname.setUpdatedTime(LocalDateTime.now());
+        //设置状态为审核失败
+        apUserRealname.setStatus(BusinessConstants.ApUserRealnameConstants.SHENHE_FALSE);
+        apUserRealnameMapper.updateById(apUserRealname);
+    }
 }

--- a/itheima-leadnews-service/itheima-leadnews-service-user/src/main/java/com/itheima/user/service/impl/ApUserRealnameServiceImpl.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-user/src/main/java/com/itheima/user/service/impl/ApUserRealnameServiceImpl.java
@@ -1,13 +1,20 @@
 package com.itheima.user.service.impl;
 
+import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.itheima.article.feign.ApAuthorFeign;
+import com.itheima.article.pojo.ApAuthor;
 import com.itheima.common.constants.BusinessConstants;
-import com.itheima.common.constants.SystemConstants;
+import com.itheima.common.pojo.Result;
+import com.itheima.media.feign.WmUserFeign;
+import com.itheima.media.pojo.WmUser;
 import com.itheima.user.mapper.ApUserMapper;
+import com.itheima.user.mapper.ApUserRealnameMapper;
 import com.itheima.user.pojo.ApUser;
 import com.itheima.user.pojo.ApUserRealname;
-import com.itheima.user.mapper.ApUserRealnameMapper;
 import com.itheima.user.service.ApUserRealnameService;
-import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -24,27 +31,76 @@ import java.time.LocalDateTime;
 @Service
 public class ApUserRealnameServiceImpl extends ServiceImpl<ApUserRealnameMapper, ApUserRealname> implements ApUserRealnameService {
 
+    private static final Logger logger = LoggerFactory.getLogger(ApUserRealnameServiceImpl.class);
+
+
     @Autowired
     private ApUserRealnameMapper apUserRealnameMapper;
+
+    @Autowired
+    private ApUserMapper apUserMapper;
+
+    @Autowired
+    private WmUserFeign wmUserFeign;
+
+    @Autowired
+    private ApAuthorFeign apAuthorFeign;
 
     @Override
     public void pass(Integer id)
     {
-        ApUserRealname apUser = new ApUserRealname();
-        apUser.setUserId(id);
-        apUser.setStatus(BusinessConstants.ApUserRealnameConstants.SHENHE_SUCCESS);
-        apUserRealnameMapper.updateById(apUser);
+        //防止apUser为空时的空指针异常
+        ApUserRealname entity = new ApUserRealname();
+        entity.setUserId(id);
 
-        //通过远程调用实现创建作者的账号  todo
+        //审核通过
+        entity.setStatus(BusinessConstants.ApUserRealnameConstants.SHENHE_SUCCESS);
+        apUserRealnameMapper.updateById(entity);
 
-        //通过远程调用实现创建作者的账号  todo
-
+        //通过远程调用实现创建作者的账号  feign远程调用 自媒体服务 创建自媒体账号
+        ApUserRealname apUserRealname = apUserRealnameMapper.selectById(id);
+        //如果该自媒体用户不存在
+        if (apUserRealname != null) {
+            ApUser apUser = apUserMapper.selectById(apUserRealname.getUserId());
+            WmUser wmUser = wmUserFeign.getByApUserId(apUser.getId());
+            //如果该用户不存在
+            if (wmUser == null) {
+                //将申请自媒体的信息复制到自媒体账号上
+                wmUser = new WmUser();
+                BeanUtils.copyProperties(entity, wmUser);
+                //设置状态-有效
+                wmUser.setStatus(BusinessConstants.WmUserConstants.WM_USER_OK);
+                //设置APP用户ID
+                wmUser.setApUserId(apUser.getId());
+                //设置创建时间
+                wmUser.setCreatedTime(LocalDateTime.now());
+                Result result = wmUserFeign.save(wmUser);
+                //Result<WmUser> result = wmUserFeign.save(wmUser);
+                if (result.isSuccess()) {
+                    logger.info("自媒体账号创建成功");
+                }
+            }
+            //通过远程调用实现创建作者的账号  feign远程调用 文章微服务 创建作者账号
+            ApAuthor apAuthor = apAuthorFeign.getByApUserId(apUser.getId());
+            //不存在账号时注册
+            if (apAuthor == null) {
+                apAuthor = new ApAuthor();
+                //作者名称就是登录名
+                apAuthor.setName(apUser.getName());
+                apAuthor.setType(BusinessConstants.ApAuthorConstants.A_MEDIA_USER);
+                apAuthor.setCreatedTime(LocalDateTime.now());
+                apAuthor.setUserId(apUser.getId());
+                apAuthor.setWmUserId(wmUser.getId());
+                apAuthorFeign.save(apAuthor);
+            }
+        }
 
     }
 
 
     @Override
-    public void reject(Integer id, String reason) {
+    public void reject(Integer id, String reason)
+    {
         ApUserRealname apUserRealname = new ApUserRealname();
         apUserRealname.setId(id);
         apUserRealname.setReason(reason);

--- a/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/media/config/SwaggerConfiguration.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/media/config/SwaggerConfiguration.java
@@ -1,0 +1,51 @@
+package com.itheima.media.config;
+
+import com.github.xiaoymin.knife4j.spring.annotations.EnableKnife4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import springfox.bean.validators.configuration.BeanValidatorPluginsConfiguration;
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger2.annotations.EnableSwagger2;
+
+import java.util.HashSet;
+
+@Configuration
+@EnableSwagger2//启用swagger
+@EnableKnife4j//启用Knife4j
+@Import(BeanValidatorPluginsConfiguration.class)
+public class SwaggerConfiguration {
+
+   @Bean
+   public Docket buildDocket() {
+      HashSet<String> strings = new HashSet<>();
+      strings.add("application/json");
+      Docket docket=new Docket(DocumentationType.SWAGGER_2)
+              .apiInfo(buildApiInfo())
+              //设置返回数据类型
+              .produces(strings)
+              //分组名称
+              //.groupName("1.0")
+              .select()
+              //这里指定Controller扫描包路径
+              .apis(RequestHandlerSelectors.basePackage("com.itheima.media.controller"))
+              //**
+              .paths(PathSelectors.any())
+              .build();
+      return docket;
+   }
+   private ApiInfo buildApiInfo() {
+      Contact contact = new Contact("steven","","");
+      return new ApiInfoBuilder()
+              .title("steven管理API文档")
+              .description("steven管理API文档")
+              .contact(contact)
+              .version("1.0.0").build();
+   }
+}


### PR DESCRIPTION
1.搭建自媒体微服务  搭建文章微服务
2.用户通过或驳回业务实现
编写controller  通过pass  驳回reject
controller 控制层 -> 业务接口 ->实现
定义实名认证相关：BusinessConstants
3.实现Feign远程调用 
3.1 在itheima-leadnews-api添加依赖 openfile(原因: feign的每一个都要用到，以及还需要用到common中的result类)
3.2 在每个相应的api中添加创建feign接口(例:itheima-leadnews-api/itheima-leadnews-article-api/src/main/java/com/itheima/article/feign/ApAuthorFeign.java)  在WmUserFeign中创建保存方法save和获取对象方法getByApUserId
3.3 实现feign接口（业务实现）在controller的 getByApUserId 
3.4 调用Feign接口实现创建自媒体账号， itheima-leadnews-service-user微服务中添加itheima-leadnews-wemedia-api和itheima-leadnews-article-ap依赖，并Feign开启接口扫描 (@EnableFeignClient(basepackages="com.itheima.*.feign"))
3.5通过审核业务实现类中实现远程调用
3.6 创建常量类 ApAuthorConstants 和 WmUserConstants
3.7 网关对接user微服务 在admin网关的yml文件中进行配置如下
        - id: user
          uri: lb://leadnews-user
          predicates:
            - Path=/user/**
          filters:
            - StripPrefix= 1