### PR TITLE
⚡️使用okhttp

### DIFF
--- a/itheima-leadnews-core/itheima-leadnews-core-feign/pom.xml
+++ b/itheima-leadnews-core/itheima-leadnews-core-feign/pom.xml
@@ -10,6 +10,12 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>itheima-leadnews-core-feign</artifactId>
+    <dependencies>
+        <!--使用okhttp-->
+        <dependency>
+            <groupId>io.github.openfeign</groupId>
+            <artifactId>feign-okhttp</artifactId>
+        </dependency>
 
-
+    </dependencies>
 </project>

--- a/itheima-leadnews-service/itheima-leadnews-service-user/src/main/resources/application.yml
+++ b/itheima-leadnews-service/itheima-leadnews-service-user/src/main/resources/application.yml
@@ -68,3 +68,14 @@ mybatis-plus:
   mapper-locations: classpath*:mapper/*.xml
   # 设置别名包扫描路径，通过该属性可以给包中的类注册别名
   type-aliases-package: com.itheima.user.pojo
+#okhttp设置
+feign:
+  client:
+    config:
+      default: # default指定的是所有的 被调用方  都设置为该配置超时时间，可以设置为某一个微服务对应的服务名
+        connectTimeout: 5000 # 链接超时时间
+        readTimeout: 5000 # 读取的超时时间
+  okhttp:
+    enabled: true
+  httpclient:
+    enabled: false


### PR DESCRIPTION
feign底层实际上是使用restTemplete 而restTemplate底层又使用到了httpclient，默认使用java自带的httpUrlConnection。默认的feign调用httpUrlConnection每次都会创建一个链接对象。效率较低。所以使用okhttp来替换，它可以使用连接池。调用效率较高。
1.在itheima-leadnews-core-feign微服务中的pom.xml中添加依赖 feign-okhttp
2.需要用到feign的微服务中(itheima-leadnews-service-user)配置