### PR TITLE
✅ FastDFS体验与测试

### DIFF
--- a/leadnews-fastdfs-demo/pom.xml
+++ b/leadnews-fastdfs-demo/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.itheima</groupId>
+    <artifactId>leadnews-fastdfs-demo</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>2.3.8.RELEASE</version>
+    </parent>
+
+    <dependencies>
+        <!--fastdfs-->
+        <dependency>
+            <groupId>com.github.tobato</groupId>
+            <artifactId>fastdfs-client</artifactId>
+            <version>1.26.5</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.junit.vintage</groupId>
+                    <artifactId>junit-vintage-engine</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+    </dependencies>
+
+
+</project>

--- a/leadnews-fastdfs-demo/src/main/java/com/loki/FastdfsApplication.java
+++ b/leadnews-fastdfs-demo/src/main/java/com/loki/FastdfsApplication.java
@@ -1,0 +1,18 @@
+package com.loki;
+
+import com.github.tobato.fastdfs.FdfsClientConfig;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Import;
+
+
+/**
+ * @author Arthurocky
+ */
+@SpringBootApplication
+@Import(FdfsClientConfig.class)
+public class FastdfsApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(FastdfsApplication.class,args);
+    }
+}

--- a/leadnews-fastdfs-demo/src/main/resources/application.yml
+++ b/leadnews-fastdfs-demo/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+fdfs:
+  so-timeout: 1501
+  connect-timeout: 601
+  thumb-image:             #缩略图生成参数
+    width: 150
+    height: 150
+  tracker-list:            #TrackerList参数,支持多个
+    - 192.168.211.136:22122

--- a/leadnews-fastdfs-demo/src/test/java/com/loki/FastadfsTest.java
+++ b/leadnews-fastdfs-demo/src/test/java/com/loki/FastadfsTest.java
@@ -1,0 +1,71 @@
+package com.loki;
+
+import com.github.tobato.fastdfs.domain.fdfs.StorePath;
+import com.github.tobato.fastdfs.domain.proto.storage.DownloadCallback;
+import com.github.tobato.fastdfs.service.FastFileStorageClient;
+import org.apache.commons.io.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.util.StringUtils;
+
+import java.io.*;
+
+
+
+@SpringBootTest
+public class FastadfsTest {
+
+    @Autowired
+    private FastFileStorageClient storageClient;
+
+    //上传图片
+    @Test
+    public void uploadFile() throws IOException {
+
+        //创建流对象
+        File file = new File("D:\\HeiMa\\images\\469670fb-0654-424f-86fc-7bbb414ef9a6.jpg");
+        FileInputStream inputStream = new FileInputStream(file);
+        long length = file.length();
+        //获取文件的扩展名不带点
+        String extName = StringUtils.getFilenameExtension(file.getName());
+        //上传图片
+        StorePath storePath = storageClient.uploadFile(
+                inputStream,
+                length,
+                extName,
+                null);
+
+        System.out.println(storePath);
+        System.out.println(storePath.getFullPath());
+    }
+
+    //删除图片
+    //
+    @Test
+    public void deleteFile() {
+        //group + path
+        storageClient.deleteFile("group1/M00/00/00/wKjTiF_BIUqAMwDrAAAl8vdCW2Y127.png");
+    }
+
+    //下载图片
+    @Test
+    public void download() throws Exception{
+        byte[] group1s = storageClient.downloadFile("group1", "M00/00/00/wKjTiF_BIrCAAn9IAAAl8vdCW2Y205.png", new DownloadCallback<byte[]>() {
+            @Override
+            public byte[] recv(InputStream ins) throws IOException {
+
+                //获取字节数组
+                byte[] bytes = IOUtils.toByteArray(ins);
+                return bytes;
+            }
+        });
+
+        //下载
+        FileOutputStream fileOutputStream = new FileOutputStream(new File("D:\\HeiMa\\images\\test\\abc.png"));
+        fileOutputStream.write(group1s);
+        fileOutputStream.close();
+    }
+
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
         <module>itheima-leadnews-service</module>
         <module>itheima-leadnews-api</module>
         <module>itheima-leadnews-common-db</module>
+        <module>leadnews-fastdfs-demo</module>
     </modules>
     <packaging>pom</packaging>
     <description>黑马头条的父工程</description>


### PR DESCRIPTION
FastDFS是一个开源的轻量级，它对文件进行管理，功能包括：文件存储、文件同步、文件访问（文件上传、文件下载）等，解决了大容量存储和负载均衡的问题。特别适合以文件为载体的在线服务，如相册网站、视频网站等等
1.新建项目：leadnews-fastdfs-demo 用作测试
2.pom文件 依赖(fastdfs-clien) web  test  排除(vintage-engine)
3.yml
fdfs:
  so-timeout: 1501
  connect-timeout: 601
  thumb-image:             #缩略图生成参数
    width: 150
    height: 150
  tracker-list:            #TrackerList参数,支持多个
    - 192.168.211.136:22122
4.编写测试类test下创建如下类 com.itheima.FastadfsTes