### PR TITLE
🚧 文件微服务搭建

### DIFF
--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/pom.xml
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>itheima-leadnews-service</artifactId>
+        <groupId>com.itheima</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>itheima-leadnews-service-dfs</artifactId>
+    <description>文件存储微服务</description>
+    <dependencies>
+        <!--fastdfs-->
+        <dependency>
+            <groupId>com.github.tobato</groupId>
+            <artifactId>fastdfs-client</artifactId>
+            <version>1.26.5</version>
+        </dependency>
+        <dependency>
+            <groupId>com.itheima</groupId>
+            <artifactId>itheima-leadnews-common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/DfsApplication.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/DfsApplication.java
@@ -1,0 +1,17 @@
+package com.itheima;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+
+/**
+ * @author Arthurocky
+ */
+@SpringBootApplication
+@EnableDiscoveryClient
+public class DfsApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(DfsApplication.class, args);
+    }
+}

--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/resources/application.yml
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/resources/application.yml
@@ -1,0 +1,83 @@
+spring:
+  profiles:
+    active: dev
+---
+server:
+  port: 9005
+spring:
+  application:
+    name: leadnews-dfs
+  profiles: dev
+  cloud:
+    nacos:
+      server-addr: 192.168.211.136:8848
+      discovery:
+        server-addr: ${spring.cloud.nacos.server-addr}
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+# fastdfs的配置
+fdfs:
+  so-timeout: 1501
+  connect-timeout: 601
+  thumb-image:             #缩略图生成参数
+    width: 150
+    height: 150
+  tracker-list:
+    - 192.168.211.136:22122 #TrackerList参数,支持多个
+  web-server-url: http://192.168.211.136/  # 设置前缀路径
+logging:
+  level.com: debug
+---
+server:
+  port: 9005
+spring:
+  application:
+    name: leadnews-dfs
+  profiles: pro
+  cloud:
+    nacos:
+      server-addr: 192.168.211.136:8848
+      discovery:
+        server-addr: ${spring.cloud.nacos.server-addr}
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+# fastdfs的配置
+fdfs:
+  so-timeout: 1501
+  connect-timeout: 601
+  thumb-image:             #缩略图生成参数
+    width: 150
+    height: 150
+  tracker-list:
+    - 192.168.211.136:22122 #TrackerList参数,支持多个
+  web-server-url: http://192.168.211.136/  # 设置前缀路径
+---
+server:
+  port: 9005
+spring:
+  application:
+    name: leadnews-dfs
+  profiles: test
+  cloud:
+    nacos:
+      server-addr: 192.168.211.136:8848
+      discovery:
+        server-addr: ${spring.cloud.nacos.server-addr}
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+# fastdfs的配置
+fdfs:
+  so-timeout: 1501
+  connect-timeout: 601
+  thumb-image:             #缩略图生成参数
+    width: 150
+    height: 150
+  tracker-list:
+    - 192.168.211.136:22122 #TrackerList参数,支持多个
+  web-server-url: http://192.168.211.136/  # 设置前缀路径

--- a/itheima-leadnews-service/pom.xml
+++ b/itheima-leadnews-service/pom.xml
@@ -17,6 +17,7 @@
         <module>itheima-leadnews-service-user</module>
         <module>itheima-leadnews-service-article</module>
         <module>itheima-leadnews-service-wemedia</module>
+        <module>itheima-leadnews-service-dfs</module>
     </modules>
     <dependencies>
         <dependency>


### PR DESCRIPTION
（1）创建itheima-leadnews-service-dfs工程微服务
（2）添加依赖  fastdfs-client \ itheima-leadnews-common
（3）创建启动类 
（4）配置yml
# fastdfs的配置
fdfs:
  so-timeout: 1501
  connect-timeout: 601
  thumb-image:             #缩略图生成参数
    width: 150
    height: 150
  tracker-list:
    - 192.168.211.136:22122 #TrackerList参数,支持多个
  web-server-url: http://192.168.211.136/  # 设置前缀路径
（5）实现图片上传--->wait for complete