### PR TITLE
🚀 添加自媒体端网关，完善自媒体用户登录功能、自媒体网关校验解析token、微服务获取登录用户信息demo

### DIFF
--- a/itheima-leadnews-api/itheima-leadnews-wemedia-api/src/main/java/com/itheima/media/vo/LoginMediaVo.java
+++ b/itheima-leadnews-api/itheima-leadnews-wemedia-api/src/main/java/com/itheima/media/vo/LoginMediaVo.java
@@ -1,0 +1,13 @@
+package com.itheima.media.vo;
+
+import lombok.Data;
+
+/**
+ * @author Arthurocky
+ */
+@Data
+public class LoginMediaVo {
+    private String name;
+    private String password;
+
+}

--- a/itheima-leadnews-common/src/main/java/com/itheima/common/constants/SystemConstants.java
+++ b/itheima-leadnews-common/src/main/java/com/itheima/common/constants/SystemConstants.java
@@ -23,4 +23,8 @@ public class SystemConstants {
      */
     public static final Integer JWT_FAIL = 0;
 
+    /**
+     * 请求头名
+     */
+    public static final String USER_HEADER_NAME = "userId";
 }

--- a/itheima-leadnews-gateway/itheima-leadnews-gateway-media/pom.xml
+++ b/itheima-leadnews-gateway/itheima-leadnews-gateway-media/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>itheima-leadnews-gateway</artifactId>
+        <groupId>com.itheima</groupId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>itheima-leadnews-gateway-media</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-gateway</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.alibaba.cloud</groupId>
+            <artifactId>spring-cloud-starter-alibaba-nacos-discovery</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.itheima</groupId>
+            <artifactId>itheima-leadnews-common</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <!--防止与gateway网关产生冲突-->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-web</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+</project>

--- a/itheima-leadnews-gateway/itheima-leadnews-gateway-media/src/main/java/com/itheima/gatewayMedia/GatewayMediaApplication.java
+++ b/itheima-leadnews-gateway/itheima-leadnews-gateway-media/src/main/java/com/itheima/gatewayMedia/GatewayMediaApplication.java
@@ -1,0 +1,17 @@
+package com.itheima.gatewayMedia;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+
+
+/**
+ * @author Arthurocky
+ */
+@SpringBootApplication
+@EnableDiscoveryClient
+public class GatewayMediaApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(GatewayMediaApplication.class,args);
+    }
+}

--- a/itheima-leadnews-gateway/itheima-leadnews-gateway-media/src/main/java/com/itheima/gatewayMedia/filter/AuthorizeFilter.java
+++ b/itheima-leadnews-gateway/itheima-leadnews-gateway-media/src/main/java/com/itheima/gatewayMedia/filter/AuthorizeFilter.java
@@ -1,0 +1,83 @@
+package com.itheima.gatewayMedia.filter;
+
+import com.itheima.common.constants.SystemConstants;
+import com.itheima.common.utils.AppJwtUtil;
+import io.jsonwebtoken.Claims;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.http.server.reactive.ServerHttpResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+/**
+ * @author Arthurocky
+ */
+@Component
+public class AuthorizeFilter implements GlobalFilter, Ordered {
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        //1.获取请求对象和响应对象
+        ServerHttpRequest request = exchange.getRequest();
+        ServerHttpResponse response = exchange.getResponse();
+        String path = request.getURI().getPath();
+
+        //2.判断当前的请求路径是去登陆，直接放行
+         if(path.endsWith("/media/wmUser/login") || path.endsWith("/v2/api-docs")){
+            return chain.filter(exchange);
+        }
+
+        //3.获取当前用户的请求头jwt信息
+        //请求头的名称为token,可能存在多个选择第一个token
+        String jwtToken = request.getHeaders().getFirst("token");
+
+        //4.判断当前令牌是否存在
+        if(StringUtils.isEmpty(jwtToken)){
+            //如果不存在，向客户端返回错误提示信息
+            response.setStatusCode(HttpStatus.UNAUTHORIZED);
+            return response.setComplete();
+        }
+
+        try {
+            //5.如果令牌存在，解析jwt令牌，判断该令牌是否合法，如果不合法，则向客户端返回错误信息
+            int result = AppJwtUtil.verifyToken(jwtToken);
+
+            if(result== SystemConstants.JWT_OK){
+                //解析数据  当前登录的自媒体的用户的ID
+                Claims claimsBody = AppJwtUtil.getClaimsBody(jwtToken);
+                //设置登录的用户的ID 头名为userId中并下发到下游微服务
+                String id = claimsBody.getId();
+
+                String userId = claimsBody.get("id").toString();
+                //添加请求头 并设置值 下放到下游微服务
+                request.mutate().header(SystemConstants.USER_HEADER_NAME,userId);
+                //exchange.getRequest().mutate().header(SystemConstants.USER_HEADER_NAME,claimsBody.get("id").toString());
+            }else {
+                response.setStatusCode(HttpStatus.UNAUTHORIZED);
+                return response.setComplete();
+            }
+        }catch (Exception e){
+            e.printStackTrace();
+            //想客户端返回错误提示信息
+            response.setStatusCode(HttpStatus.UNAUTHORIZED);
+            return response.setComplete();
+        }
+
+        //6.放行
+        return chain.filter(exchange);
+    }
+
+    /**
+     * 优先级设置
+     * 值越小，优先级越高
+     * @return
+     */
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/itheima-leadnews-gateway/itheima-leadnews-gateway-media/src/main/resources/application.yml
+++ b/itheima-leadnews-gateway/itheima-leadnews-gateway-media/src/main/resources/application.yml
@@ -1,0 +1,114 @@
+spring:
+  profiles:
+    active: dev
+---
+server:
+  port: 6002
+spring:
+  application:
+    name: leadnews-media-gateway
+  profiles: dev
+  cloud:
+    nacos:
+      server-addr: 192.168.211.136:8848
+      discovery:
+        server-addr: ${spring.cloud.nacos.server-addr}
+    gateway:
+      globalcors:
+        cors-configurations:
+          '[/**]': # 匹配所有请求
+            allowedOrigins: "*" #跨域处理 允许所有的域
+            allowedHeaders: "*"
+            allowedMethods: # 支持的方法
+              - GET
+              - POST
+              - PUT
+              - DELETE
+      routes:
+        # 平台管理
+        - id: media
+          uri: lb://leadnews-wemedia
+          predicates:
+            - Path=/media/**
+          filters:
+            - StripPrefix= 1
+        - id: dfs
+          uri: lb://leadnews-dfs
+          predicates:
+            - Path=/dfs/**
+          filters:
+            - StripPrefix= 1
+---
+server:
+  port: 6002
+spring:
+  application:
+    name: leadnews-media-gateway
+  profiles: test
+  cloud:
+    nacos:
+      server-addr: 192.168.211.136:8848
+      discovery:
+        server-addr: ${spring.cloud.nacos.server-addr}
+    gateway:
+      globalcors:
+        cors-configurations:
+          '[/**]': # 匹配所有请求
+            allowedOrigins: "*" #跨域处理 允许所有的域
+            allowedHeaders: "*"
+            allowedMethods: # 支持的方法
+              - GET
+              - POST
+              - PUT
+              - DELETE
+      routes:
+        # 平台管理
+        - id: media
+          uri: lb://leadnews-wemedia
+          predicates:
+            - Path=/media/**
+          filters:
+            - StripPrefix= 1
+        - id: dfs
+          uri: lb://leadnews-dfs
+          predicates:
+            - Path=/dfs/**
+          filters:
+            - StripPrefix= 1
+---
+server:
+  port: 6002
+spring:
+  application:
+    name: leadnews-media-gateway
+  profiles: pro
+  cloud:
+    nacos:
+      server-addr: 192.168.211.136:8848
+      discovery:
+        server-addr: ${spring.cloud.nacos.server-addr}
+    gateway:
+      globalcors:
+        cors-configurations:
+          '[/**]': # 匹配所有请求
+            allowedOrigins: "*" #跨域处理 允许所有的域
+            allowedHeaders: "*"
+            allowedMethods: # 支持的方法
+              - GET
+              - POST
+              - PUT
+              - DELETE
+      routes:
+        # 平台管理
+        - id: media
+          uri: lb://leadnews-wemedia
+          predicates:
+            - Path=/media/**
+          filters:
+            - StripPrefix= 1
+        - id: dfs
+          uri: lb://leadnews-dfs
+          predicates:
+            - Path=/dfs/**
+          filters:
+            - StripPrefix= 1

--- a/itheima-leadnews-gateway/pom.xml
+++ b/itheima-leadnews-gateway/pom.xml
@@ -10,6 +10,9 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>itheima-leadnews-gateway</artifactId>
     <description>网关统一管理父工程</description>
+    <modules>
+        <module>itheima-leadnews-gateway-media</module>
+    </modules>
     <packaging>pom</packaging>
 
 

--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/DfsApplication.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/DfsApplication.java
@@ -1,8 +1,10 @@
 package com.itheima;
 
+import com.github.tobato.fastdfs.FdfsClientConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.context.annotation.Import;
 
 
 /**
@@ -10,6 +12,8 @@ import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
  */
 @SpringBootApplication
 @EnableDiscoveryClient
+//可以省略，DFS中已经配置了
+@Import(FdfsClientConfig.class)
 public class DfsApplication {
     public static void main(String[] args) {
         SpringApplication.run(DfsApplication.class, args);

--- a/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/MediaApplication.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/MediaApplication.java
@@ -5,6 +5,7 @@ import org.mybatis.spring.annotation.MapperScan;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
+import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -16,6 +17,7 @@ import org.springframework.context.annotation.Bean;
 */
 @SpringBootApplication
 @MapperScan(basePackages = "com.itheima.media.mapper")//扫描mapper接口所在的包即可
+//@EnableFeignClients
 @EnableDiscoveryClient//启用注册与发现
 public class MediaApplication {
     public static void main(String[] args) {

--- a/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/media/controller/WmMaterialController.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/media/controller/WmMaterialController.java
@@ -1,21 +1,21 @@
 package com.itheima.media.controller;
 
-
+import com.itheima.common.pojo.Result;
+import com.itheima.core.controller.AbstractCoreController;
 import com.itheima.media.pojo.WmMaterial;
 import com.itheima.media.service.WmMaterialService;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.beans.factory.annotation.Autowired;
-import io.swagger.annotations.Api;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import com.itheima.core.controller.AbstractCoreController;
+
+import java.time.LocalDateTime;
+
 
 /**
-* <p>
-* 自媒体图文素材信息表 控制器</p>
-* @author ljh
-* @since 2021-12-22
-*/
-@Api(value="自媒体图文素材信息表",tags = "WmMaterialController")
+ * @author Arthurocky
+ */
 @RestController
 @RequestMapping("/wmMaterial")
 public class WmMaterialController extends AbstractCoreController<WmMaterial> {
@@ -29,5 +29,23 @@ public class WmMaterialController extends AbstractCoreController<WmMaterial> {
         this.wmMaterialService=wmMaterialService;
     }
 
+    /**
+     * 重写父类方法 实现添加素材
+     */
+    @PostMapping
+    @Override
+    public Result insert(@RequestBody WmMaterial record) {
+        //1.设置补充属性
+        //todo 先硬编码 设置为该素材所属的自媒体账号ID
+        record.setUserId(1000);
+        //未收藏
+        record.setIsCollection(0);
+        //图片
+        record.setType(0);
+        //创建时间
+        record.setCreatedTime(LocalDateTime.now());
+        //2.保存到数据库中
+        wmMaterialService.save(record);
+        return Result.ok(record);
+    }
 }
-

--- a/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/media/controller/WmUserController.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/media/controller/WmUserController.java
@@ -2,15 +2,17 @@ package com.itheima.media.controller;
 
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.itheima.common.exception.LeadNewsException;
+import com.itheima.common.pojo.Result;
 import com.itheima.core.controller.AbstractCoreController;
 import com.itheima.media.pojo.WmUser;
 import com.itheima.media.service.WmUserService;
+import com.itheima.media.vo.LoginMediaVo;
 import io.swagger.annotations.Api;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 /**
 * <p>
@@ -43,6 +45,19 @@ public class WmUserController extends AbstractCoreController<WmUser> {
         QueryWrapper<WmUser> queryWrapper = new QueryWrapper<>();
         queryWrapper.eq("ap_user_id",apUserId);
         return  wmUserService.getOne(queryWrapper);
+    }
+
+    /**
+     * 登录功能实现
+     * @param loginMediaVo
+     * @return
+     * @throws LeadNewsException
+     */
+    @PostMapping("/login")
+    public Result<Map<String,Object>> login(@RequestBody LoginMediaVo loginMediaVo) throws LeadNewsException
+    {
+        Map<String,Object> info = wmUserService.login(loginMediaVo);
+        return Result.ok(info);
     }
 
 }

--- a/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/media/service/WmUserService.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/media/service/WmUserService.java
@@ -1,7 +1,11 @@
 package com.itheima.media.service;
 
+import com.itheima.common.exception.LeadNewsException;
 import com.itheima.media.pojo.WmUser;
 import com.baomidou.mybatisplus.extension.service.IService;
+import com.itheima.media.vo.LoginMediaVo;
+
+import java.util.Map;
 
 /**
  * <p>
@@ -12,5 +16,7 @@ import com.baomidou.mybatisplus.extension.service.IService;
  * @since 2021-12-22
  */
 public interface WmUserService extends IService<WmUser> {
+
+    Map<String, Object> login(LoginMediaVo loginMediaVo) throws LeadNewsException;
 
 }

--- a/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/media/service/impl/WmUserServiceImpl.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-wemedia/src/main/java/com/itheima/media/service/impl/WmUserServiceImpl.java
@@ -1,10 +1,22 @@
 package com.itheima.media.service.impl;
 
-import com.itheima.media.pojo.WmUser;
-import com.itheima.media.mapper.WmUserMapper;
-import com.itheima.media.service.WmUserService;
+import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.extension.service.impl.ServiceImpl;
+import com.itheima.common.exception.LeadNewsException;
+import com.itheima.common.utils.AppJwtUtil;
+import com.itheima.media.mapper.WmUserMapper;
+import com.itheima.media.pojo.WmUser;
+import com.itheima.media.service.WmUserService;
+import com.itheima.media.vo.LoginMediaVo;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.DigestUtils;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.Resource;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * <p>
@@ -17,4 +29,49 @@ import org.springframework.stereotype.Service;
 @Service
 public class WmUserServiceImpl extends ServiceImpl<WmUserMapper, WmUser> implements WmUserService {
 
+    @Autowired
+    private WmUserMapper wmUserMapper;
+
+    @Override
+    public Map<String, Object> login(LoginMediaVo loginMediaVo) throws LeadNewsException
+    {
+        //用户名
+        String name = loginMediaVo.getName();
+
+        //密码
+        String password = loginMediaVo.getPassword();
+
+        //1.登录界面用户名或密码为空时
+        if (StringUtils.isEmpty(name) || StringUtils.isEmpty(password)) {
+            throw new LeadNewsException("用户名和密码不能为空");
+        }
+
+        //2.根据用户名 从数据库查询数据 如果没有找到 报错
+/*        QueryWrapper<WmUser> queryWrapper = new QueryWrapper<>();
+        queryWrapper.eq("name", name);
+        WmUser wmUser = wmUserMapper.selectOne(queryWrapper);*/
+        LambdaQueryWrapper<WmUser> wrapper = new LambdaQueryWrapper<>();
+        wrapper.eq(WmUser::getName,name);
+        WmUser wmUser = this.getOne(wrapper);
+        if (wmUser == null) {
+            throw new LeadNewsException("用户名或者密码错误");
+        }
+
+        //3.获取页面传递过来的密码 进行md5加密   再和数据库的密文进行对比  如果对比失败  报错
+        String temp = loginMediaVo.getPassword() + wmUser.getSalt();
+        //进行md5加密
+        String passwordFromWebMd5 = DigestUtils.md5DigestAsHex(temp.getBytes());
+        if (passwordFromWebMd5.equals(wmUser.getPassword())) {
+            throw new LeadNewsException("用户名或者密码错误");
+        }
+
+        //4. 密码正确，生成令牌返回给前端
+        String token = AppJwtUtil.createToken(Long.valueOf(wmUser.getId()));
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("token", token);
+        map.put("headPic", wmUser.getImage());
+        map.put("nickName", wmUser.getNickname());
+        //info.put("nickName",wmUser.getNickname());
+        return map;
+    }
 }


### PR DESCRIPTION
1.搭建自媒体网关
2.实现自媒体用户登录功能  
-设置接收前端对象LoginMediaVo
-定义login方法 实现思路：(判断传来的对象是否为空 为空 则报错提示不能为空-->根据用户名 从数据库查询数据 如果没有找到 报错  --> 获取页面传递过来的密码 进行md5加密   再和数据库的密文进行对比  如果对比失败  报错--> 到达这里说明成功，生成令牌返回给前端)
3.自媒体网关校验解析token(AuthorizeFilter):  
-入参: ServerWebExchange exchange, GatewayFilterChain chain
-实现思路: 获取请求对象和响应对象 exchange.getRequest()\exchange.getResponse() -->判断当前的请求是否为登录 path.endsWith("/media/wmUser/login")，如果是，直接放行-->获取当前用户的请求头jwt信息request.getHeaders().getFirst("token") -->判断当前令牌是否存在 如果不存在，向客户端返回错误提示信息 ;如果令牌存在，解析jwt令牌，判断该令牌是否有效-->有效则设置登录的用户的ID 头名为userId中并下发到下游微服务
4.实现微服务获取登录用户信息demo
