### PR TITLE
🎨 使用模板模式对文件上传功能进行改进

### DIFF
--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/controller/BaseController.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/controller/BaseController.java
@@ -1,0 +1,51 @@
+package com.itheima.controller;
+
+import com.itheima.common.pojo.Result;
+import com.itheima.common.utils.RequestContextUtil;
+import com.itheima.pojo.BaseFileModel;
+import com.itheima.service.IFileService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Arthurocky
+ */
+@RestController
+@RequestMapping("/dfs")
+public class BaseController {
+
+    @Autowired
+    //根据bean名字获取,指定使用fdfsFile
+    @Qualifier(value = "fdfsFileTemplate")
+    private IFileService iFileService;
+
+
+    @PostMapping("/upload")
+    public Result<Map<String, String>> upload(MultipartFile file) throws Exception
+    {
+
+        Map<String, String> map = new HashMap<>();
+        if (!file.isEmpty()) {
+            BaseFileModel fileModel = new BaseFileModel();
+            //登录的用户的ID对应的用户名 todo
+            String userInfo = RequestContextUtil.getUserInfo();
+            //file.getName();上传图片的原名
+            fileModel.setAuthor(userInfo);
+            fileModel.setSize(file.getSize());
+            fileModel.setName(file.getOriginalFilename());
+            fileModel.setContent(file.getBytes());
+            String path = iFileService.uploadFile(fileModel);
+            //设置返回图片的路径
+            map.put("url", path);
+            return Result.ok(map);
+        }
+        return Result.errorMessage("错误");
+    }
+}

--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/controller/FileController.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/controller/FileController.java
@@ -18,7 +18,7 @@ import java.util.Map;
 /**
  * @author Arthurocky
  */
-@RestController
+//@RestController
 @RequestMapping("/dfs")
 public class FileController {
 

--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/pojo/BaseFileModel.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/pojo/BaseFileModel.java
@@ -1,0 +1,48 @@
+package com.itheima.pojo;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.util.DigestUtils;
+
+/**
+ * @author Arthurocky
+ * 需要的基本内容
+ */
+@Data
+@NoArgsConstructor
+public class BaseFileModel {
+    /**
+     * 上传文件的作者
+     */
+    private String author = "default";
+
+    /**
+     * 文件大小
+     */
+    private Long size;
+
+    /**
+     * 文件源文件名称
+     */
+    private String name;
+
+    /**
+     * 上传文件的md5值
+     */
+    private String md5;
+
+    /**
+     * 上传文件本身数据
+     */
+    private byte[] content;
+
+    public BaseFileModel(String author, Long size, String name, byte[] content) {
+        this.size = size;
+        this.name = name;
+        this.content = content;
+        this.author = author;
+        StringBuilder stringBuilder = new StringBuilder();
+        this.md5 = DigestUtils.md5DigestAsHex(stringBuilder.append(this.author).append(this.name).append(this.size).toString().getBytes());
+
+    }
+}

--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/pojo/DFSType.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/pojo/DFSType.java
@@ -1,0 +1,22 @@
+package com.itheima.pojo;
+
+/**
+ * @author Arthurocky
+ * 设置支持设置的枚举
+ */
+
+public enum DFSType {
+    /**
+     * fastdfs
+     */
+    FASTDFS,
+    /**
+     * 七牛
+     */
+    QINIUDFS,
+    /**
+     * 阿里云oss
+     */
+    OSSDFS;
+
+}

--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/service/IFileService.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/service/IFileService.java
@@ -1,0 +1,37 @@
+package com.itheima.service;
+
+import com.itheima.pojo.BaseFileModel;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+/**
+ * @author Arthurocky
+ */
+public interface IFileService {
+
+    /**
+     * 上传文件
+     *
+     * @param fileModel
+     * @return 文件的路径信息
+     */
+    public String uploadFile(BaseFileModel fileModel);
+
+    /**
+     * 删除文件
+     *
+     * @param fullPath
+     * @return 是否成功
+     */
+    public boolean delete(String fullPath);
+
+    /**
+     * 批量下载
+     * @param fullPath
+     * @return
+     */
+    List<byte[]> download(List<String> fullPath);
+
+
+}

--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/service/impl/AbstractDfsTemplate.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/service/impl/AbstractDfsTemplate.java
@@ -1,0 +1,33 @@
+package com.itheima.service.impl;
+
+import com.itheima.pojo.DFSType;
+import com.itheima.service.IFileService;
+import org.springframework.beans.factory.InitializingBean;
+
+public abstract class AbstractDfsTemplate implements IFileService, InitializingBean {
+
+
+    /**
+     * 定义支持的类型 必须设置值
+     *
+     * @return
+     */
+    public abstract DFSType support();
+
+    @Override
+    public void afterPropertiesSet() throws Exception {
+        DFSType[] values = DFSType.values();
+
+        boolean flag = false;
+        for (DFSType value : values) {
+            DFSType support = support();
+            if(support==value){
+                flag=true;
+                break;
+            }
+        }
+        if(!flag){
+            throw new java.lang.RuntimeException("不支持的dfs类型");
+        }
+    }
+}

--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/service/impl/FdfsFileTemplate.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/service/impl/FdfsFileTemplate.java
@@ -1,0 +1,79 @@
+package com.itheima.service.impl;
+
+import com.github.tobato.fastdfs.domain.conn.FdfsWebServer;
+import com.github.tobato.fastdfs.domain.fdfs.MetaData;
+import com.github.tobato.fastdfs.domain.fdfs.StorePath;
+import com.github.tobato.fastdfs.service.FastFileStorageClient;
+import com.itheima.pojo.BaseFileModel;
+import com.itheima.pojo.DFSType;
+import org.apache.commons.io.IOUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.io.ByteArrayInputStream;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author Arthurocky
+ */
+@Component
+public class FdfsFileTemplate extends AbstractDfsTemplate {
+
+    @Autowired
+    private FastFileStorageClient client;
+
+    @Autowired
+    private FdfsWebServer fdfsWebServer;
+
+    @Override
+    public String uploadFile(BaseFileModel fileModel) {
+        HashSet<MetaData> metaData = new HashSet<>();
+        //设置md5作为设置图片的签名
+        metaData.add(new MetaData("md5", fileModel.getMd5()));
+        ByteArrayInputStream byteInputStream = new ByteArrayInputStream(fileModel.getContent());
+        StorePath storePath = client.uploadFile(
+                byteInputStream,
+                fileModel.getSize(),
+                StringUtils.getFilenameExtension(fileModel.getName()),
+                metaData);
+        String webServerUrl = fdfsWebServer.getWebServerUrl();
+        return webServerUrl + storePath.getFullPath();
+    }
+
+    @Override
+    public boolean delete(String fullPath) {
+        try {
+            client.deleteFile(fullPath);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public List<byte[]> download(List<String> fullPaths) {
+
+        List<byte[]> picList = fullPaths.stream().map(
+                fullpath -> {
+                    try {
+                        StorePath storePath = StorePath.parseFromUrl(fullpath);
+                        byte[] bytes = client.downloadFile(storePath.getGroup(), storePath.getPath(), ins -> IOUtils.toByteArray(ins));
+                        return bytes;
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        return null;
+                    }
+                }
+        ).filter(bytes -> bytes != null).collect(Collectors.toList());
+        return picList;
+    }
+
+    @Override
+    public DFSType support() {
+        return DFSType.FASTDFS;
+    }
+}

--- a/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/service/impl/OssFileTemplate.java
+++ b/itheima-leadnews-service/itheima-leadnews-service-dfs/src/main/java/com/itheima/service/impl/OssFileTemplate.java
@@ -1,0 +1,44 @@
+package com.itheima.service.impl;
+import com.itheima.pojo.BaseFileModel;
+import com.itheima.pojo.DFSType;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * @author Arthurocky
+ */
+@Component
+public class OssFileTemplate extends AbstractDfsTemplate {
+    //oss的逻辑
+    @Override
+    public String uploadFile(BaseFileModel fileModel) {
+
+
+        //5.do
+
+        return null;
+    }
+
+
+    @Override
+    public boolean delete(String fullPath) {
+
+        //5.do
+
+        return false;
+    }
+
+    @Override
+    public List<byte[]> download(List<String> fullPath) {
+
+
+        //5.do
+        return null;
+    }
+
+    @Override
+    public DFSType support() {
+        return DFSType.OSSDFS;
+    }
+}


### PR DESCRIPTION
1.创建枚举DFSType 类 用于限定支持的类型 
2.创建接口IFileService，用于设置通用的行为 (上传、下载等)
3.创建POJO -BaseFileModel 用于设置通用的上传图片需要的基本内容(作者、大小、名字等)
4.创建抽象类AbstractDfsTemplate实现接口IFileService, InitializingBean，并设置抽象方法 用于约定子类的实现是否满足要求
5.创建两个模板类FdfsFileTemplate 、OssFileTemplate 继承抽象类AbstractDfsTemplate， 分别表示不同的操作模板，并实现方法
6.controller中注入不同的Template 并指定使用哪一个即可，这样即使后面需要调整，就只需要修改controller @Qualifier(value="fdfsFileTemplate")

-但是还是有问题，因为上线之后需要进行调整，就需要修改之后，重新重启，我们如果不想重启该怎么办呢？如果动态根据不同的类型选择不同的service的实现类进行注入呢？答案是策略模式!

